### PR TITLE
nix: Add server wrapper that include runtime deps

### DIFF
--- a/distros/nix/server.nix
+++ b/distros/nix/server.nix
@@ -1,0 +1,20 @@
+{
+    lib, stdenv, makeWrapper, version, buildkit, nerdctl, pipreqs, cli
+}:
+let
+    runtimeDeps = [ buildkit nerdctl pipreqs ];
+in
+    stdenv.mkDerivation {
+        pname = "ayup-server";
+        meta.mainProgram = "ay";
+        inherit version;
+        src = cli;
+        nativeBuildInputs = [ makeWrapper ];
+        buildInputs = runtimeDeps;
+        installPhase = ''
+            mkdir -p $out/bin
+            cp $src/bin/ay $out/bin/
+            wrapProgram $out/bin/ay \
+              --prefix PATH : ${ lib.makeBinPath runtimeDeps }
+       '';
+    }

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,9 @@
         GOOS = "linux";
         GOARCH = "amd64";
       };
+      server = pkgs.callPackage ./distros/nix/server.nix {
+        inherit version cli;
+      };
   in
     {
       devShells.${system}.default = pkgs.mkShell {
@@ -67,6 +70,8 @@
       packages.${system} = {
         inherit src;
         inherit cli cli-darwin-amd64 cli-darwin-arm64 cli-linux-arm64 cli-linux-amd64;
+        inherit server;
+
         default = cli;
         dev = pkgs.stdenv.mkDerivation {
           pname = "dev";


### PR DESCRIPTION
While we don't have various deps bundled in the exe or in the case of pipreqs we don't fetch it; use Nix to package them.